### PR TITLE
Allow tasty-1.4

### DIFF
--- a/hpc-codecov.cabal
+++ b/hpc-codecov.cabal
@@ -67,7 +67,7 @@ test-suite test-main
                      , hpc-codecov
                        --
                      , tar         >= 0.5   && < 0.6
-                     , tasty       >= 1.0   && < 1.4
+                     , tasty       >= 1.0   && < 1.5
                      , tasty-hunit >= 0.8   && < 1.0
   default-language:    Haskell2010
   ghc-options:         -Wall -threaded -rtsopts


### PR DESCRIPTION
Related to commercialhaskell/stackage#5795; I haven't tested this locally, I just figured it would be easy to make the change and let CI yell at me if something broke.