### PR TITLE
Bump upper bound of hpc to 0.8

### DIFF
--- a/hpc-codecov.cabal
+++ b/hpc-codecov.cabal
@@ -65,7 +65,7 @@ library
                      , containers  >= 0.6   && < 0.8
                      , directory   >= 1.3.0 && < 1.4.0
                      , filepath    >= 1.4.1 && < 1.5
-                     , hpc         >= 0.6   && < 0.7
+                     , hpc         >= 0.6   && < 0.8
                      , time        >= 1.8   && < 1.13
   default-language:    Haskell2010
   ghc-options:         -Wall


### PR DESCRIPTION
I recently released a new major version of hpc: 0.7.0.0. The only significant difference is that hpc has dropped all promises about safe/trustworthy Haskell. This is due to the fact that we depend on the directory package which recently dropped its SafeHaskell promises.
If you don't use SafeHaskell then you shouldn't notice a difference, except that we are now compatible with newer versions of the directory package.