### PR TITLE
Support ghc 9.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Revision history for hpc-codecov
 
+## Unreleased
+
+- Suppress warning messages when compiling with ghc 9.10.
+
+- Modify version range of filepath to >= 1.5.0 && < 1.6.
+
 ## 0.6.0.0 -- 2024-04-26
 
 - Add "--expr-only" option. This option will ignore other constructor

--- a/hpc-codecov.cabal
+++ b/hpc-codecov.cabal
@@ -86,7 +86,7 @@ library
                      , bytestring  >= 0.10  && < 0.13
                      , containers  >= 0.6   && < 0.8
                      , directory   >= 1.3.0 && < 1.4.0
-                     , filepath    >= 1.4.1 && < 1.5
+                     , filepath    >= 1.4.1 && < 1.6
                      , hpc         >= 0.6   && < 0.8
                      , time        >= 1.9   && < 1.13
   default-language:    Haskell2010

--- a/src/Trace/Hpc/Codecov/Report/Emit.hs
+++ b/src/Trace/Hpc/Codecov/Report/Emit.hs
@@ -17,9 +17,13 @@ module Trace.Hpc.Codecov.Report.Emit
 
 -- base
 import           Data.Char                         (isUpper)
-import           Data.List                         (foldl', intercalate,
+import           Data.List                         (intercalate,
                                                     intersperse)
 import           System.IO.Unsafe                  (unsafePerformIO)
+
+#if !MIN_VERSION_base(4,20,0)
+import           Data.List                         (foldl')
+#endif
 
 #if !MIN_VERSION_bytestring(0,11,0)
 import           Text.Printf                       (printf)

--- a/src/Trace/Hpc/Codecov/Report/Entry.hs
+++ b/src/Trace/Hpc/Codecov/Report/Entry.hs
@@ -1,4 +1,5 @@
 -- |
+{-# LANGUAGE CPP #-}
 -- Module:     Trace.Hpc.Codecov.Report.Entry
 -- Copyright:  (c) 2023 8c6794b6
 -- License:    BSD3
@@ -25,8 +26,12 @@ import           Control.Exception           (ErrorCall, handle, throw,
 import           Control.Monad               (when)
 import           Control.Monad.ST            (ST)
 import           Data.Function               (on)
-import           Data.List                   (foldl', intercalate)
+import           Data.List                   (intercalate)
 import           System.IO                   (hPutStrLn, stderr)
+
+#if !MIN_VERSION_base(4,20,0)
+import           Data.List                   (foldl')
+#endif
 
 -- array
 import           Data.Array.Base             (unsafeAt)


### PR DESCRIPTION
Surround the import of "foldl'" with CPP macro to suppress warning messages in ghc 9.10.1. Relax upper bound of the filepath package dependency.