### PR TITLE
Build executable with ubuntu-24.04-arm runner image

### DIFF
--- a/.github/workflows/cabal-install.yml
+++ b/.github/workflows/cabal-install.yml
@@ -18,6 +18,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
+          - ubuntu-24.04-arm
           - macos-latest
           - windows-latest
 
@@ -44,7 +45,7 @@ jobs:
               ;;
           esac
 
-          exename=hpc-codecov-${{ runner.os }}${ext}
+          exename=hpc-codecov-${{ runner.os }}-${{ runner.arch }}${ext}
           echo "exename=${exename}" >> $GITHUB_OUTPUT
           echo "path=bin/${exename}" >> $GITHUB_OUTPUT
 
@@ -71,13 +72,13 @@ jobs:
         if: runner.os != 'macos'
         run: strip -s ${{ steps.os.outputs.path }}
 
-      - name: Compress executable
+      - name: Comparess executable
         if: runner.os != 'macos'
-        uses: svenstaro/upx-action@v2
+        uses: crazy-max/ghaction-upx@v3
         with:
-          files: ${{ steps.os.outputs.path }}
+          files: |
+            ${{ steps.os.outputs.path }}
           args: -9
-          strip: false
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,10 +26,11 @@ jobs:
           prerelease: true
           body: ''
           files: |
-            bin/hpc-codecov-Linux
-            bin/hpc-codecov-Linux-static
-            bin/hpc-codecov-Windows.exe
-            bin/hpc-codecov-macOS
+            bin/hpc-codecov-Linux-ARM64
+            bin/hpc-codecov-Linux-X64
+            bin/hpc-codecov-Linux-X64-static
+            bin/hpc-codecov-Windows-X64.exe
+            bin/hpc-codecov-macOS-ARM64
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/stack.yml
+++ b/.github/workflows/stack.yml
@@ -18,6 +18,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
+          - ubuntu-24.04-arm
           - macos-latest
           - windows-latest
 

--- a/.github/workflows/static-executable.yml
+++ b/.github/workflows/static-executable.yml
@@ -8,7 +8,7 @@ jobs:
     name: Build static executable for Linux
     runs-on: ubuntu-latest
     env:
-      exe: hpc-codecov-Linux-static
+      exe: hpc-codecov-Linux-X64-static
     container:
       image: fossa/haskell-static-alpine:ghc-9.8.2
     steps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,2 @@
 FROM busybox:musl
-COPY hpc-codecov-Linux-static /bin/hpc-codecov
+COPY hpc-codecov-Linux-X64-static /bin/hpc-codecov


### PR DESCRIPTION
Add ubuntu-24.04-arm to the "runs-on" section in cabal-install and stack jobs. Add hpc-codecov-Linux-ARM64 to release file list.

Use ghaction-upx@v3 instead of svenstaro/upx-action@v2, to support ubuntu-24.04-arm runner image.

Add architecture to the executable name in released files.